### PR TITLE
feat(environment): allow job command and arg overrides

### DIFF
--- a/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
@@ -105,6 +105,8 @@ func defaultEnvironmentBuild(obj *EnvironmentBuildSpec) {
 	if obj.Exclude == nil {
 		obj.Exclude = []string{}
 	}
+
+	defaultEnvironmentVars(&obj.Vars)
 }
 
 func defaultEnvironmentS3Spec(obj *EnvironmentS3Spec) {

--- a/pkg/apis/seaway.ctx.sh/v1beta1/types.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/types.go
@@ -103,6 +103,11 @@ type EnvironmentBuildSpec struct {
 	// excluded.
 	// +optional
 	Exclude []string `json:"exclude"`
+	// Vars is a list of environment variables that will be set for the build jobs.
+	// It contains both corev1.EnvVar and corev1.EnvFromSource types.
+	// +optional
+	// +nullable
+	Vars EnvironmentVars `json:"vars"`
 }
 
 type EnvironmentVars struct {


### PR DESCRIPTION
Allow for job command and argument overrides to initially support custom images.   This still doesn't address everything since there is a lot of dynamic configuration that will need to take place.  In the future, add templatable variables that can be replaced with things like the registry host.  The immediate work around will be to add configurations to custom build images as environment variables. 