### PR TITLE
feat(registry): use the s3 storage driver by default

### DIFF
--- a/config/shared/registry/creds.yaml
+++ b/config/shared/registry/creds.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+stringData:
+  REGISTRY_STORAGE_S3_ACCESSKEY: $SEAWAY_S3_ACCESS_KEY
+  REGISTRY_STORAGE_S3_SECRETKEY: $SEAWAY_S3_SECRET_KEY
+kind: Secret
+metadata:
+  name: seaway-creds
+  namespace: registries

--- a/config/shared/registry/kustomization.yaml
+++ b/config/shared/registry/kustomization.yaml
@@ -6,4 +6,5 @@ commonAnnotations:
   ctx.sh/support: "https://github.com/ctxswitch/seaway/issues"
 resources:
   - namespace.yaml
+  - creds.yaml
   - registry.yaml

--- a/config/shared/registry/registry.yaml
+++ b/config/shared/registry/registry.yaml
@@ -1,19 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: seaway-hl
-  namespace: registries
-spec:
-  ports:
-  - name: api
-    port: 5000
-  clusterIP: None
-  selector:
-    app: seaway
----
-apiVersion: v1
-kind: Service
-metadata:
   name: seaway
   namespace: registries
 spec:
@@ -27,7 +14,7 @@ spec:
     app: seaway
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: seaway
   namespace: registries
@@ -36,7 +23,6 @@ spec:
   selector:
     matchLabels:
       app: seaway
-  serviceName: seaway
   template:
     metadata:
       labels:
@@ -47,17 +33,27 @@ spec:
         image: registry:2
         ports:
         - containerPort: 5000
-        volumeMounts:
-        - mountPath: /var/lib/registry
-          name: seaway-claim
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Retain
-  volumeClaimTemplates:
-  - metadata:
-      name: seaway-claim
-    spec:
-      accessModes: [ReadWriteOnce]
-      resources:
-        requests:
-          storage: 10Gi
+        envFrom:
+        - secretRef:
+            name: seaway-creds
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        - name: REGISTRY_STORAGE
+          value: s3
+        - name: REGISTRY_STORAGE_S3_REGION
+          value: us-east-1
+        - name: REGISTRY_STORAGE_S3_REGIONENDPOINT
+          value: http://minio.minio.svc.cluster.local:80
+        - name: REGISTRY_STORAGE_S3_BUCKET
+          value: seaway
+        - name: REGISTRY_STORAGE_S3_ENCRYPT
+          value: "false"
+        - name: REGISTRY_STORAGE_S3_SECURE
+          value: "false"
+        - name: REGISTRY_STORAGE_S3_CHUNKSIZE
+          value: "5242880"
+        - name: REGISTRY_STORAGE_S3_ROOTDIRECTORY
+          value: /registry
+        - name: REGISTRY_STORAGE_S3_FORCEPATHSTYLE
+          value: "true"

--- a/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
@@ -26,7 +26,7 @@ const (
 	DefaultRegion            = "us-east-1"
 	DefaultEndpoint          = "http://localhost:80"
 	DefaultForcePathStyle    = true
-	DefaultPrefix            = "contexts"
+	DefaultPrefix            = "artifacts"
 	DefaultBuildImage        = "gcr.io/kaniko-project/executor:latest"
 	DefaultDockerfile        = "Dockerfile"
 	DefaultPlatform          = runtime.GOOS + "/" + runtime.GOARCH

--- a/pkg/apis/seaway.ctx.sh/v1beta1/types.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/types.go
@@ -35,10 +35,10 @@ type EnvironmentPort struct {
 }
 
 type EnvironmentS3Spec struct {
-	// Bucket is the name of the S3 bucket where the build context is stored.
+	// Bucket is the name of the S3 bucket where the source artifacts stored.
 	// +optional
 	Bucket *string `json:"bucket"`
-	// Prefix is the path prefix within the bucket where the build context is stored.
+	// Prefix is the path prefix within the bucket where the source artifacts stored.
 	// +optional
 	Prefix *string `json:"prefix"`
 	// Region is the AWS region where the S3 bucket is located.  This is required by

--- a/pkg/controller/environment/controller.go
+++ b/pkg/controller/environment/controller.go
@@ -85,15 +85,15 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// There's probably a cleaner way to handle the initial checks here.
 	switch {
+	case env.HasDeviated():
+		logger.Info("environment been updated, redeploying")
+		env.Status.Stage = v1beta1.EnvironmentStageInitialize
 	case env.HasFailed():
-		logger.Info("environment has failed, skipping", "stage", env.Status.Stage)
+		logger.Info("environment has failed, skipping")
 		return ctrl.Result{}, nil
 	case env.IsDeployed():
 		logger.Info("environment is deployed", "revision", env.Spec.Revision)
 		return ctrl.Result{}, nil
-	case env.Status.Stage == v1beta1.EnvironmentStageInitialize:
-		logger.Info("environment is initializing", "revision", env.Spec.Revision)
-		env.Status.Stage = v1beta1.EnvironmentCheckBuildJob
 	}
 
 	status := env.Status.DeepCopy()

--- a/pkg/controller/environment/stage/build.go
+++ b/pkg/controller/environment/stage/build.go
@@ -79,8 +79,8 @@ func (b *Build) buildJob(job *batchv1.Job, env *v1beta1.Environment) error {
 	// TODO: ttl, activedeadline and backoff should be configurable
 	job.Spec.TTLSecondsAfterFinished = ptr.To(int32(600))
 	// TODO: Change me back
-	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(60))
-	job.Spec.BackoffLimit = ptr.To(int32(0))
+	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(300))
+	job.Spec.BackoffLimit = ptr.To(int32(1))
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	job.Spec.PodFailurePolicy = &batchv1.PodFailurePolicy{
 		Rules: []batchv1.PodFailurePolicyRule{


### PR DESCRIPTION
* [x] Shared registry will now use s3 as the persistence layer for images.  This allows the service to be agnostic since we drop the need for PVs in any cluster.  Since we require S3, might as well use it.
* [x] Fix a bug introduced in the last PR where we were no longer checking to see if the environment had a revision deviation on reconcile.
* [x] Changed `contexts` path in s3 to `artifacts` to more accurately describe what is in the and to differentiate it from kube contexts.  Contexts were originally chosen because they also represent the base directory and originally all files were being uploaded into the directory.  It was later chosen to create an archive and upload it as a revision artifact.
* [x] Reverted the original job configuration changes so we allow a single retry and the deadline seconds is now 5 minutes.
