### PR TITLE
fix(registry): disable redirects

### DIFF
--- a/config/shared/registry/registry.yaml
+++ b/config/shared/registry/registry.yaml
@@ -57,3 +57,7 @@ spec:
           value: /registry
         - name: REGISTRY_STORAGE_S3_FORCEPATHSTYLE
           value: "true"
+        - name: REGISTRY_STORAGE_DELETE_ENABLED
+          value: "true"
+        - name: REGISTRY_STORAGE_REDIRECT_DISABLE
+          value: "true"


### PR DESCRIPTION
By default the registry will redirect pulls and pushes to the storage backend.  This poses a problem with the node's container runtime accessing the registry as it cannot resolve any of the service names.  I had missed that the first time through.  Also enabled deletion while I was at it.