### PR TITLE
feat(init): add resource initialization from cli

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"math/big"
+	"os"
+)
+
+// Credentials represents the stored credentials that seaway uses to authenticate
+// with it's dependent resources.  This is super temporary and will be replaced
+// with a more secure solution in the future.
+type Credentials struct {
+	AccessKey         string `json:"access_key"`
+	SecretKey         string `json:"secret_key"`
+	MinioRootUser     string `json:"minioRootUser"`
+	MinioRootPassword string `json:"minioRootPassword"`
+}
+
+// NewCredentials creates a new set of credentials for seaway to use.
+func NewCredentials(filename string) (*Credentials, error) {
+	secretKey, err := generateRandomString(24)
+	if err != nil {
+		return nil, err
+	}
+
+	rootPassword, err := generateRandomString(24)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := &Credentials{
+		AccessKey:         "seaway",
+		SecretKey:         secretKey,
+		MinioRootUser:     "minio",
+		MinioRootPassword: rootPassword,
+	}
+
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.WriteFile(filename, data, 0600); err != nil {
+		return nil, err
+	}
+
+	return creds, nil
+}
+
+// LoadCredentials loads the credentials from the specified file.
+func LoadCredentials(filename string) (*Credentials, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := &Credentials{}
+	if err := json.Unmarshal(data, creds); err != nil {
+		return nil, err
+	}
+
+	return creds, nil
+}
+
+func (c *Credentials) GetAccessKey() string {
+	return c.AccessKey
+}
+
+func (c *Credentials) GetSecretKey() string {
+	return c.SecretKey
+}
+
+func (c *Credentials) GetMinioRootUser() string {
+	return c.MinioRootUser
+}
+
+func (c *Credentials) GetMinioRootPassword() string {
+	return c.MinioRootPassword
+}
+
+func generateRandomString(n int) (string, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+
+	return string(ret), nil
+}

--- a/pkg/cmd/seactl/init/defaults.go
+++ b/pkg/cmd/seactl/init/defaults.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Seaway Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package init
+
+import "time"
+
+const (
+	DefaultLogLevel = 0
+	DefaultTimeout  = 10 * time.Minute
+)

--- a/pkg/cmd/seactl/init/script.go
+++ b/pkg/cmd/seactl/init/script.go
@@ -2,6 +2,8 @@ package init
 
 // Uggg. Quick and dirty way to compact the responsibility of the user to create these
 // and add it to the cli.
+
+//nolint:gochecknoglobals
 var sharedScript = `
 if [[ x$SEAWAY_S3_ACCESS_KEY == "x" ]]; then
   echo "SEAWAY_S3_ACCESS_KEY is not set"

--- a/pkg/cmd/seactl/init/script.go
+++ b/pkg/cmd/seactl/init/script.go
@@ -1,0 +1,63 @@
+package init
+
+// Uggg. Quick and dirty way to compact the responsibility of the user to create these
+// and add it to the cli.
+var sharedScript = `
+if [[ x$SEAWAY_S3_ACCESS_KEY == "x" ]]; then
+  echo "SEAWAY_S3_ACCESS_KEY is not set"
+  exit 1
+fi
+
+if [[ x$SEAWAY_S3_SECRET_KEY == "x" ]]; then
+  echo "SEAWAY_S3_SECRET_KEY is not set"
+  exit 1
+fi
+
+if [[ x$MINIO_ROOT_USER == "x" ]]; then
+  echo "MINIO_ROOT_USER is not set"
+  exit 1
+fi
+
+if [[ x$MINIO_ROOT_PASSWORD == "x" ]]; then
+  echo "MINIO_ROOT_PASSWORD is not set"
+  exit 1
+fi
+
+SEAWAY_SHARED_BASE_URL=https://github.com/ctxswitch/seaway/config/shared
+SEAWAY_CNTL_BASE_URL=https://github.com/ctxswitch/seaway/config/seaway
+
+echo "###############################################################"
+echo "# Deploying cert-manager"
+echo "###############################################################"
+kustomize build "${SEAWAY_SHARED_BASE_URL}/cert-manager" | envsubst | kubectl ${CONTEXT} apply -f - && \
+kubectl wait --for=condition=available --timeout=120s deploy -l app.kubernetes.io/group=cert-manager -n cert-manager
+
+echo "###############################################################"
+echo "# Deploying minio-operator"
+echo "###############################################################"
+kustomize build ${SEAWAY_SHARED_BASE_URL}/minio | envsubst | kubectl ${CONTEXT} apply -f - && \
+kubectl wait --for=condition=available --timeout=120s deploy/minio-operator -n minio-operator
+
+echo "###############################################################"
+echo "# Deploying minio-tenant, registry, and other resources"
+echo "###############################################################"
+kustomize build ${SEAWAY_SHARED_BASE_URL}/overlays/local | envsubst | kubectl ${CONTEXT} apply -f -
+
+
+if [[ ${ENABLE_TAILSCALE} == "true" ]]; then
+  echo "###############################################################"
+  echo "# Deploying tailscale"
+  echo "###############################################################"
+  kustomize build ${SEAWAY_SHARED_BASE_URL}/tailscale | envsubst | kubectl ${CONTEXT} apply -f -
+fi
+
+echo "###############################################################"
+echo "# Deploying the seaway controller"
+echo "###############################################################"
+kustomize build ${SEAWAY_CNTL_BASE_URL}/base | envsubst | kubectl ${CONTEXT} apply -f - && \
+
+echo
+echo
+echo "Finished deploying shared resources."
+echo
+`

--- a/pkg/cmd/seactl/init/shared.go
+++ b/pkg/cmd/seactl/init/shared.go
@@ -109,7 +109,9 @@ func (s *Shared) RunE(cmd *cobra.Command, args []string) error {
 	script := exec.Command("bash", "-c", sharedScript)
 	script.Stderr = os.Stderr
 	script.Stdout = os.Stdout
-	script.Start()
+	if err := script.Start(); err != nil {
+		console.Fatal("Error starting script: %v", err)
+	}
 
 	if err := script.Wait(); err != nil {
 		console.Fatal("Error running script: %v", err)

--- a/pkg/cmd/seactl/init/shared.go
+++ b/pkg/cmd/seactl/init/shared.go
@@ -93,7 +93,7 @@ func (s *Shared) RunE(cmd *cobra.Command, args []string) error {
 		console.Fatal("Unable to set MINIO_ROOT_PASSWORD")
 	}
 
-	if err := os.Setenv("CONTEXT", s.context); err != nil {
+	if err := os.Setenv("CONTEXT", "--context="+s.context); err != nil {
 		console.Fatal("Unable to set CONTEXT")
 	}
 

--- a/pkg/cmd/seactl/init/shared.go
+++ b/pkg/cmd/seactl/init/shared.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Seaway Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package init
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+
+	"ctx.sh/seaway/pkg/auth"
+	"ctx.sh/seaway/pkg/build"
+	"ctx.sh/seaway/pkg/console"
+	"github.com/spf13/cobra"
+)
+
+const (
+	SharedUsage     = "shared"
+	SharedShortDesc = "Initializes seaway resources for a kubernetes cluster."
+	SharedLongDesc  = `Initializes seaway resources for a kubernetes cluster.`
+)
+
+type Shared struct {
+	logLevel        int8
+	context         string
+	enableTailscale bool
+}
+
+func NewShared() *Shared {
+	return &Shared{}
+}
+
+// RunE is the main function for the init command which installs all required
+// seaway resources on a cluster.  This is a ***very*** temporary solution to
+// keep the install as simple as possible for users.  In the future, there will
+// be no external dependencies and the install will be done completely by seactl.
+func (s *Shared) RunE(cmd *cobra.Command, args []string) error {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		console.Fatal("kubectl is not installed")
+	}
+
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		console.Fatal("kustomize is not installed")
+	}
+
+	if _, err := exec.LookPath("envsubst"); err != nil {
+		console.Fatal("envsubst is not installed")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		console.Fatal("Unable to determine user home directory")
+	}
+
+	var creds *auth.Credentials
+	filename := home + "/.seaway/creds"
+	if _, err := os.Stat(filename); err != nil {
+		creds, err = auth.NewCredentials(filename)
+		if err != nil {
+			console.Fatal("Unable to create credentials file: %v", err)
+		}
+	} else {
+		creds, err = auth.LoadCredentials(filename)
+		if err != nil {
+			console.Fatal("Unable to load credentials file: %v", err)
+		}
+	}
+
+	if err := os.Setenv("SEAWAY_S3_ACCESS_KEY", creds.GetAccessKey()); err != nil {
+		console.Fatal("Unable to set SEAWAY_S3_ACCESS_KEY")
+	}
+
+	if err := os.Setenv("SEAWAY_S3_SECRET_KEY", creds.GetSecretKey()); err != nil {
+		console.Fatal("Unable to set SEAWAY_S3_SECRET_KEY")
+	}
+
+	if err := os.Setenv("MINIO_ROOT_USER", creds.GetMinioRootUser()); err != nil {
+		console.Fatal("Unable to set MINIO_ROOT_USER")
+	}
+
+	if err := os.Setenv("MINIO_ROOT_PASSWORD", creds.MinioRootPassword); err != nil {
+		console.Fatal("Unable to set MINIO_ROOT_PASSWORD")
+	}
+
+	if err := os.Setenv("CONTEXT", s.context); err != nil {
+		console.Fatal("Unable to set CONTEXT")
+	}
+
+	if err := os.Setenv("SEAWAY_VERSION", build.Version); err != nil {
+		console.Fatal("Unable to set SEAWAY_VERSION")
+	}
+
+	enabled := strconv.FormatBool(s.enableTailscale)
+	if err := os.Setenv("ENABLE_TAILSCALE", enabled); err != nil {
+		console.Fatal("Unable to set ENABLE_TAILSCALE")
+	}
+
+	script := exec.Command("bash", "-c", sharedScript)
+	script.Stderr = os.Stderr
+	script.Stdout = os.Stdout
+	script.Start()
+
+	if err := script.Wait(); err != nil {
+		console.Fatal("Error running script: %v", err)
+	}
+
+	return nil
+}
+
+// Command creates the clean command.
+func (s *Shared) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   SharedUsage,
+		Short: SharedShortDesc,
+		Long:  SharedLongDesc,
+		RunE:  s.RunE,
+	}
+
+	cmd.PersistentFlags().Int8VarP(&s.logLevel, "log-level", "", DefaultLogLevel, "set the log level (integer value)")
+	cmd.PersistentFlags().StringVarP(&s.context, "context", "c", "", "specify the kubernetes context to use")
+	cmd.PersistentFlags().BoolVarP(&s.enableTailscale, "enable-tailscale", "", false, "enable tailscale ingress controller on the cluster")
+	return cmd
+}

--- a/pkg/cmd/seactl/root.go
+++ b/pkg/cmd/seactl/root.go
@@ -16,19 +16,16 @@ package main
 
 import (
 	"ctx.sh/seaway/pkg/build"
-	"ctx.sh/seaway/pkg/cmd/seactl/deps"
-	"ctx.sh/seaway/pkg/cmd/seactl/env"
+	depscmd "ctx.sh/seaway/pkg/cmd/seactl/deps"
+	envcmd "ctx.sh/seaway/pkg/cmd/seactl/env"
+	initcmd "ctx.sh/seaway/pkg/cmd/seactl/init"
 	"github.com/spf13/cobra"
 )
 
 const (
 	RootUsage     = "seactl [command] [args...]"
-	RootShortDesc = "Build controller and image sync tool for kubernetes"
-	RootLongDesc  = `Coral is a build controller and image sync tool for kubernetes.  It
-provides components for watching source repositories for changes and building containers
-when changes and conditions are detected.  It also provides a tool for syncrhonizing the
-new images to nodes in a cluster based off of node labels bypassing the need for external
-registries.`
+	RootShortDesc = "CLI utility for managing Seaway development environments."
+	RootLongDesc  = `CLI utility for managing Seaway development environments.`
 	// TODO: Make these descriptions more informational.
 	DepsUsage     = "deps [subcommand] [context]"
 	DepsShortDesc = "Utility to manage application dependencies"
@@ -36,6 +33,9 @@ registries.`
 	EnvUsage      = "env [subcommand] [context]"
 	EnvShortDesc  = "Utility to manage development environments"
 	EnvLongDesc   = `Utility to manage development environments`
+	InitUsage     = "init [subcommand]"
+	InitShortDesc = "Utility to initialize Seaway resources"
+	InitLongDesc  = `Utility to initialize Seaway resources`
 )
 
 type Root struct{}
@@ -62,11 +62,12 @@ func (r *Root) Command() *cobra.Command {
 			_ = cmd.Help()
 		},
 		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceErrors: false,
 	}
 
 	rootCmd.AddCommand(EnvCommand())
 	rootCmd.AddCommand(DepsCommand())
+	rootCmd.AddCommand(InitCommand())
 	return rootCmd
 }
 
@@ -82,8 +83,8 @@ func DepsCommand() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-	cmd.AddCommand(deps.NewApply().Command())
-	cmd.AddCommand(deps.NewDelete().Command())
+	cmd.AddCommand(depscmd.NewApply().Command())
+	cmd.AddCommand(depscmd.NewDelete().Command())
 
 	return cmd
 }
@@ -100,7 +101,23 @@ func EnvCommand() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-	cmd.AddCommand(env.NewSync().Command())
-	cmd.AddCommand(env.NewClean().Command())
+	cmd.AddCommand(envcmd.NewSync().Command())
+	cmd.AddCommand(envcmd.NewClean().Command())
+	return cmd
+}
+
+func InitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   InitUsage,
+		Short: InitShortDesc,
+		Long:  InitLongDesc,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+		SilenceUsage:  true,
+		SilenceErrors: false,
+	}
+
+	cmd.AddCommand(initcmd.NewShared().Command())
 	return cmd
 }


### PR DESCRIPTION
Adds a first pass hack for resource initialization utilizing external applications.  For now we:

* [x] Create random creds and store them in `~/.seaway/creds`.
* [x] Check to see if kubectl, kustomize, and envsubst.
* [x] Sets environment variables to control the install script
* [x] Run the install script.

There are a couple of additional options to install tailscale and use a different k8s context.