### PR TITLE
feat(cmd): add logs command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/pkg/cmd/seactl/logs/app.go
+++ b/pkg/cmd/seactl/logs/app.go
@@ -1,0 +1,80 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+
+	"ctx.sh/seaway/pkg/apis/seaway.ctx.sh/v1beta1"
+	"ctx.sh/seaway/pkg/console"
+	"ctx.sh/seaway/pkg/kube/client"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	AppLogsUsage     = "app [envionment]"
+	AppLogsShortDesc = "Stream logs from the application pods."
+	AppLogsLongDesc  = `Stream logs from the application pods.`
+)
+
+type AppLogs struct {
+	follow     bool
+	tail       int64
+	timestamps bool
+}
+
+func NewAppLogs() *AppLogs {
+	return &AppLogs{}
+}
+func (l *AppLogs) RunE(cmd *cobra.Command, args []string) error {
+	kubeContext := cmd.Root().Flags().Lookup("context").Value.String()
+	ctx := context.Background()
+
+	if len(args) != 1 {
+		return fmt.Errorf("expected environment name")
+	}
+
+	var manifest v1beta1.Manifest
+	err := manifest.Load("manifest.yaml")
+	if err != nil {
+		console.Fatal("Unable to load manifest")
+	}
+
+	env, err := manifest.GetEnvironment(args[0])
+	if err != nil {
+		console.Fatal("Build environment '%s' not found in the manifest", args[0])
+	}
+
+	streamer, err := client.NewLogStreamer(kubeContext, corev1.PodLogOptions{
+		Follow:     l.follow,
+		TailLines:  &l.tail,
+		Timestamps: l.timestamps,
+		Container:  "app",
+	})
+	if err != nil {
+		console.Fatal(err.Error())
+	}
+
+	labels := fmt.Sprintf("app=%s,group=application", manifest.Name)
+	err = streamer.PodLogs(ctx, env.Namespace, labels)
+	if err != nil && err != context.Canceled {
+		console.Fatal(err.Error())
+	}
+
+	return nil
+}
+
+func (l *AppLogs) Command() *cobra.Command {
+	logsCmd := &cobra.Command{
+		Use:   AppLogsUsage,
+		Short: AppLogsShortDesc,
+		Long:  AppLogsLongDesc,
+		RunE:  l.RunE,
+	}
+
+	logsCmd.Flags().BoolVarP(&l.follow, "follow", "f", false, "Specify if the logs should be streamed.")
+	logsCmd.Flags().Int64VarP(&l.tail, "tail", "", 100, "Number of lines to show from the end of the logs.")
+	logsCmd.Flags().BoolVarP(&l.timestamps, "timestamps", "", false, "Include timestamps on each line in the log output.")
+
+	return logsCmd
+}

--- a/pkg/cmd/seactl/logs/build.go
+++ b/pkg/cmd/seactl/logs/build.go
@@ -1,0 +1,80 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+
+	"ctx.sh/seaway/pkg/apis/seaway.ctx.sh/v1beta1"
+	"ctx.sh/seaway/pkg/console"
+	"ctx.sh/seaway/pkg/kube/client"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	BuildLogsUsage     = "build [envionment]"
+	BuildLogsShortDesc = "Stream logs from the builder pods."
+	BuildLogsLongDesc  = `Stream logs from the builder pods.`
+)
+
+type BuildLogs struct {
+	follow     bool
+	tail       int64
+	timestamps bool
+}
+
+func NewBuildLogs() *BuildLogs {
+	return &BuildLogs{}
+}
+func (l *BuildLogs) RunE(cmd *cobra.Command, args []string) error {
+	kubeContext := cmd.Root().Flags().Lookup("context").Value.String()
+	ctx := context.Background()
+
+	if len(args) != 1 {
+		return fmt.Errorf("expected environment name")
+	}
+
+	var manifest v1beta1.Manifest
+	err := manifest.Load("manifest.yaml")
+	if err != nil {
+		console.Fatal("Unable to load manifest")
+	}
+
+	env, err := manifest.GetEnvironment(args[0])
+	if err != nil {
+		console.Fatal("Build environment '%s' not found in the manifest", args[0])
+	}
+
+	streamer, err := client.NewLogStreamer(kubeContext, corev1.PodLogOptions{
+		Follow:     l.follow,
+		TailLines:  &l.tail,
+		Timestamps: l.timestamps,
+		Container:  "builder",
+	})
+	if err != nil {
+		console.Fatal(err.Error())
+	}
+
+	labels := fmt.Sprintf("app=%s,group=build", manifest.Name)
+	err = streamer.PodLogs(ctx, env.Namespace, labels)
+	if err != nil && err != context.Canceled {
+		console.Fatal(err.Error())
+	}
+
+	return nil
+}
+
+func (l *BuildLogs) Command() *cobra.Command {
+	logsCmd := &cobra.Command{
+		Use:   BuildLogsUsage,
+		Short: BuildLogsShortDesc,
+		Long:  BuildLogsLongDesc,
+		RunE:  l.RunE,
+	}
+
+	logsCmd.Flags().BoolVarP(&l.follow, "follow", "f", false, "Specify if the logs should be streamed.")
+	logsCmd.Flags().Int64VarP(&l.tail, "tail", "", 100, "Number of lines to show from the end of the logs.")
+	logsCmd.Flags().BoolVarP(&l.timestamps, "timestamps", "", false, "Include timestamps on each line in the log output.")
+
+	return logsCmd
+}

--- a/pkg/cmd/seactl/root.go
+++ b/pkg/cmd/seactl/root.go
@@ -19,6 +19,7 @@ import (
 	depscmd "ctx.sh/seaway/pkg/cmd/seactl/deps"
 	envcmd "ctx.sh/seaway/pkg/cmd/seactl/env"
 	initcmd "ctx.sh/seaway/pkg/cmd/seactl/init"
+	"ctx.sh/seaway/pkg/cmd/seactl/logs"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,9 @@ const (
 	InitUsage     = "init [subcommand]"
 	InitShortDesc = "Utility to initialize Seaway resources"
 	InitLongDesc  = `Utility to initialize Seaway resources`
+	LogsUsage     = "logs [subcommand]"
+	LogsShortDesc = "Utility to stream logs from the development environment"
+	LogsLongDesc  = `Utility to stream logs from the development environment`
 )
 
 type Root struct{}
@@ -68,6 +72,7 @@ func (r *Root) Command() *cobra.Command {
 	rootCmd.AddCommand(EnvCommand())
 	rootCmd.AddCommand(DepsCommand())
 	rootCmd.AddCommand(InitCommand())
+	rootCmd.AddCommand(LogsCommand())
 
 	rootCmd.PersistentFlags().StringP("context", "", "", "set the Kubernetes context")
 	return rootCmd
@@ -121,5 +126,22 @@ func InitCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(initcmd.NewShared().Command())
+	return cmd
+}
+
+func LogsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   LogsUsage,
+		Short: LogsShortDesc,
+		Long:  LogsLongDesc,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+		SilenceUsage:  true,
+		SilenceErrors: false,
+	}
+
+	cmd.AddCommand(logs.NewAppLogs().Command())
+	cmd.AddCommand(logs.NewBuildLogs().Command())
 	return cmd
 }

--- a/pkg/controller/environment/collector/builder.go
+++ b/pkg/controller/environment/collector/builder.go
@@ -89,7 +89,8 @@ func (b *Builder) buildJob() *batchv1.Job { //nolint:funlen
 			// TODO: Allow secure as well based on the registry uri parsing.
 			"--insecure",
 			"--insecure-pull",
-			"--verbosity=trace",
+			// TODO: Make this configurable
+			"--verbosity=info",
 		}
 	}
 
@@ -129,8 +130,8 @@ func (b *Builder) buildJob() *batchv1.Job { //nolint:funlen
 
 	spec := batchv1.JobSpec{
 		// TODO: ttl, activedeadline and backoff should be configurable
-		TTLSecondsAfterFinished: ptr.To(int32(600)),
-		ActiveDeadlineSeconds:   ptr.To(int64(300)),
+		TTLSecondsAfterFinished: ptr.To(int32(3600)),
+		ActiveDeadlineSeconds:   ptr.To(int64(600)),
 		BackoffLimit:            ptr.To(int32(1)),
 		PodFailurePolicy: &batchv1.PodFailurePolicy{
 			Rules: []batchv1.PodFailurePolicyRule{
@@ -147,8 +148,9 @@ func (b *Builder) buildJob() *batchv1.Job { //nolint:funlen
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app":  env.GetName(),
-					"etag": env.GetRevision(),
+					"app":   env.GetName(),
+					"etag":  env.GetRevision(),
+					"group": "build",
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -207,13 +209,15 @@ func (b *Builder) buildDeployment() *appsv1.Deployment {
 		Replicas: env.Spec.Replicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"app": env.GetName(),
+				"app":   env.GetName(),
+				"group": "application",
 			},
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app": env.GetName(),
+					"app":   env.GetName(),
+					"group": "application",
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -259,7 +263,8 @@ func (b *Builder) buildService() *corev1.Service {
 	spec := corev1.ServiceSpec{
 		Ports: ports,
 		Selector: map[string]string{
-			"app": env.GetName(),
+			"app":   env.GetName(),
+			"group": "application",
 		},
 		Type: corev1.ServiceTypeClusterIP,
 	}

--- a/pkg/controller/environment/handler.go
+++ b/pkg/controller/environment/handler.go
@@ -53,7 +53,10 @@ func (h *Handler) reconcile(ctx context.Context) (ctrl.Result, error) {
 		env.Status.Stage = v1beta1.EnvironmentStageInitialize
 	case env.IsDeployed():
 		logger.V(5).Info("handling reconciliation for existing revision")
-		env.Status.Stage = v1beta1.EnvironmentStageDeploy
+		// env.Status.Stage = v1beta1.EnvironmentStageDeploy
+		// TODO: Think about how we can handle a redeploy if only the env resources
+		// have changed and not the image itself.  Might want to add a manifest hash.
+		return ctrl.Result{}, nil
 	}
 
 	status := env.Status.DeepCopy()

--- a/pkg/kube/client/log_stream.go
+++ b/pkg/kube/client/log_stream.go
@@ -1,0 +1,191 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/polymorphichelpers"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+const (
+	DefaultLogStreamerTimeout = 10 * time.Second
+)
+
+type objWriter struct {
+	objRef corev1.ObjectReference
+	writer io.Writer
+}
+
+// Write writes the provided bytes to the writer prefixed with the pods suffix.
+func (ow *objWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	suffix := strings.Split(ow.objRef.Name, "-")
+	prefix := []byte(fmt.Sprintf("[%s] ", suffix[len(suffix)-1]))
+
+	n, err := ow.writer.Write(append(prefix, p...))
+	if n > len(p) {
+		return len(p), err
+	}
+	return n, err
+}
+
+type LogSteamer struct {
+	client  *Client
+	options corev1.PodLogOptions
+}
+
+// NewLogStreamer creates a new log streamer for the provided kube context and logging options.
+func NewLogStreamer(kubeContext string, opts corev1.PodLogOptions) (*LogSteamer, error) {
+	c, err := NewClient("", kubeContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LogSteamer{
+		client:  c,
+		options: opts,
+	}, nil
+}
+
+// PodLogs streams logs from the pods that match the provided labels.
+func (ls *LogSteamer) PodLogs(ctx context.Context, ns, labels string) error {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+
+	gv := scheme.Scheme.VersionsForGroupKind(schema.GroupKind{
+		Group: "",
+		Kind:  "PodList",
+	})
+
+	// Get the result object for the identified pod.  We use the label selector
+	// so we can get any number of replicas that are running for the deployment.
+	// Because of the label selector we'll always get a PodList object back.
+	factory := ls.client.Factory()
+	result := factory.NewBuilder().
+		WithScheme(s, gv...).
+		NamespaceParam(ns).DefaultNamespace().
+		SingleResourceType().
+		ResourceTypes("pods").
+		LabelSelector(labels).Do()
+
+	// Returns the list of resource infos that were found in the previous step.
+	// Note to future self:  This represents the actual resource objects and not
+	// the individual pods.  The pods are accessed through the resource object.
+	infos, err := result.Infos()
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			err = fmt.Errorf("no resources found in %s namespace", ns)
+		}
+		return err
+	}
+
+	// If we don't have any pods listed in the resource object then bail.
+	obj := infos[0].Object
+	if len(obj.(*corev1.PodList).Items) == 0 {
+		return fmt.Errorf("no resources found in %s namespace", ns)
+	}
+
+	return ls.stream(ctx, obj)
+}
+
+// stream initiates the log streaming process for the provided resource object.
+func (ls *LogSteamer) stream(ctx context.Context, obj runtime.Object) error {
+	requests, err := polymorphichelpers.LogsForObjectFn(ls.client, obj, &ls.options, DefaultLogStreamerTimeout, false)
+	if err != nil {
+		return err
+	}
+
+	if ls.options.Follow && len(requests) > 1 {
+		return parallelConsumer(ctx, requests)
+	}
+
+	fmt.Println("sequentially")
+	return sequentialConsumer(ctx, requests)
+}
+
+// parallelConsumer streams logs from multiple pods concurrently.  This borrows
+// heavily from the kubectl codebase.
+func parallelConsumer(ctx context.Context, requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
+	reader, writer := io.Pipe()
+	wg := &sync.WaitGroup{}
+	wg.Add(len(requests))
+	for objRef, request := range requests {
+		go func(objRef corev1.ObjectReference, request rest.ResponseWrapper) {
+			defer wg.Done()
+			out := &objWriter{
+				objRef: objRef,
+				writer: writer,
+			}
+			if err := consume(ctx, request, out); err != nil {
+				// Ignore any errors.
+				fmt.Fprintf(writer, "error: %v\n", err)
+			}
+
+		}(objRef, request)
+	}
+
+	go func() {
+		wg.Wait()
+		writer.Close()
+	}()
+
+	_, err := io.Copy(os.Stdout, reader)
+	return err
+}
+
+// sequentialConsumer streams logs from multiple pods sequentially.  This borrows
+// heavily from the kubectl codebase.
+func sequentialConsumer(ctx context.Context, requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
+	for objRef, request := range requests {
+		out := &objWriter{
+			objRef: objRef,
+			writer: os.Stdout,
+		}
+		if err := consume(ctx, request, out); err != nil {
+			// Ignore any errors.
+			fmt.Fprintf(os.Stdout, "error: %v\n", err)
+		}
+	}
+
+	return nil
+}
+
+// consume reads the stream from the provided request and writes it to the provided writer.
+// This also borrows heavily from the kubectl codebase.
+func consume(ctx context.Context, request rest.ResponseWrapper, out io.Writer) error {
+	readCloser, err := request.Stream(ctx)
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	r := bufio.NewReader(readCloser)
+	for {
+		bytes, err := r.ReadBytes('\n')
+		if _, err := out.Write(bytes); err != nil {
+			return err
+		}
+
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			return nil
+		}
+	}
+}

--- a/pkg/kube/client/log_stream.go
+++ b/pkg/kube/client/log_stream.go
@@ -114,7 +114,6 @@ func (ls *LogSteamer) stream(ctx context.Context, obj runtime.Object) error {
 		return parallelConsumer(ctx, requests)
 	}
 
-	fmt.Println("sequentially")
 	return sequentialConsumer(ctx, requests)
 }
 
@@ -135,7 +134,6 @@ func parallelConsumer(ctx context.Context, requests map[corev1.ObjectReference]r
 				// Ignore any errors.
 				fmt.Fprintf(writer, "error: %v\n", err)
 			}
-
 		}(objRef, request)
 	}
 
@@ -177,8 +175,8 @@ func consume(ctx context.Context, request rest.ResponseWrapper, out io.Writer) e
 	r := bufio.NewReader(readCloser)
 	for {
 		bytes, err := r.ReadBytes('\n')
-		if _, err := out.Write(bytes); err != nil {
-			return err
+		if _, werr := out.Write(bytes); werr != nil {
+			return werr
 		}
 
 		if err != nil {


### PR DESCRIPTION
Adds two new commands:

* `logs app` - output logs from the application pod(s).
* `logs build` - output logs from the build pod(s).

Options include tail (lines), follow, and enable/disable timestamps.  The stream consumers borrow heavily from the kubectl implementation but are specialized for the narrow needs that seaway has.

* [x] New labels to differentiate build and application pods.  I'm probably going to revisit the label names later.
* [x] Log stream implementation.
* [x] Increase TTL for job deletion since we can actually use it now.
* [x] (fix) remove redeployment step which caused a reconcile infinite loop.   

