### PR TITLE
feat: set default endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ localdev-shared:
 	@$(KUBECTL) wait --for=condition=available --timeout=120s deploy/minio-operator -n minio-operator
 	@$(KUSTOMIZE) build config/shared/overlays/$(ENV) | envsubst | $(KUBECTL) apply -f -
 
+.PHONY: localdev-seaway
+localdev-seaway:
+	@$(KUSTOMIZE) build config/seaway/overlays/$(ENV) | envsubst | $(KUBECTL) apply -f -
+
 .PHONY: clean-localdev-shared
 clean-localdev-shared:
 	@$(KUBECTL) delete -k config/shared/overlays/$(ENV)

--- a/config/seaway/base/kustomization.yaml
+++ b/config/seaway/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ../crd
   - ../rbac
   - ../webhook
+  - ../defaults
   - controller.yaml

--- a/config/seaway/crd/seaway.ctx.sh_environments.yaml
+++ b/config/seaway/crd/seaway.ctx.sh_environments.yaml
@@ -85,8 +85,6 @@ spec:
                 type: array
               config:
                 type: string
-              endpoint:
-                type: string
               lifecycle:
                 nullable: true
                 properties:

--- a/config/seaway/webhook/service.yaml
+++ b/config/seaway/webhook/service.yaml
@@ -11,6 +11,7 @@ spec:
     - port: 443
       protocol: TCP
       targetPort: 9443
+      # TODO: Dont't actually need a nodeport for normal deploys.
       nodePort: 30100
   selector:
     app: seaway-controller

--- a/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/defaults.go
@@ -25,7 +25,6 @@ const (
 	DefaultReplicas            = 1
 	DefaultBucket              = "seaway"
 	DefaultRegion              = "us-east-1"
-	DefaultEndpoint            = "http://localhost:8080"
 	DefaultForcePathStyle      = true
 	DefaultPrefix              = "artifacts"
 	DefaultBuildImage          = "gcr.io/kaniko-project/executor:latest"
@@ -58,11 +57,6 @@ func defaultEnvironmentSpec(obj *EnvironmentSpec) {
 
 	if obj.Config == "" {
 		obj.Config = DefaultConfigName
-	}
-
-	if obj.Endpoint == nil {
-		obj.Endpoint = new(string)
-		*obj.Endpoint = DefaultEndpoint
 	}
 
 	if obj.Resources == nil {

--- a/pkg/apis/seaway.ctx.sh/v1beta1/defaults_test.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/defaults_test.go
@@ -26,7 +26,6 @@ func TestDefaulted(t *testing.T) {
 			},
 			Command:       nil,
 			Config:        DefaultConfigName,
-			Endpoint:      ptr.To(DefaultEndpoint),
 			Lifecycle:     nil,
 			LivenessProbe: nil,
 			Network: &EnvironmentNetwork{

--- a/pkg/apis/seaway.ctx.sh/v1beta1/manifest_environment_spec.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/manifest_environment_spec.go
@@ -19,6 +19,10 @@ import (
 	"strings"
 )
 
+const (
+	DefaultEndpoint = "http://localhost:8080"
+)
+
 var (
 	DefaultExcludes = []string{
 		"vendor/*",
@@ -42,6 +46,7 @@ func (me *ManifestEnvironmentSpec) UnmarshalYAML(unmarshal func(interface{}) err
 	type ManifestEnvironmentSpecDefaulted ManifestEnvironmentSpec
 	var defaults = ManifestEnvironmentSpecDefaulted{
 		Namespace: "default",
+		Endpoint:  DefaultEndpoint,
 	}
 
 	out := defaults

--- a/pkg/apis/seaway.ctx.sh/v1beta1/types.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/types.go
@@ -173,10 +173,6 @@ type EnvironmentSpec struct {
 	// +optional
 	// +nullable
 	Command []string `json:"command" yaml:"command"`
-	// Endpoint is the Seaway API endpoint that the client will use to interact
-	// with the environment.
-	// +optional
-	Endpoint *string `json:"endpoint" yaml:"endpoint"`
 	// Lifecycle is the lifecycle spec for the deployed application.
 	// +optional
 	// +nullable
@@ -304,8 +300,12 @@ type ManifestDependency struct {
 // ManifestEnvironmentSpec is a spec for an environment in the manifest and
 // is used by the client.
 type ManifestEnvironmentSpec struct {
-	Name            string               `yaml:"name"`
-	Namespace       string               `yaml:"namespace"`
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+	// Endpoint is the Seaway API endpoint that the client will use to interact
+	// with the environment.
+	// +optional
+	Endpoint        string               `json:"endpoint" yaml:"endpoint"`
 	Dependencies    []ManifestDependency `yaml:"dependencies"`
 	EnvironmentSpec `yaml:",inline"`
 }

--- a/pkg/apis/seaway.ctx.sh/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/zz_generated.deepcopy.go
@@ -298,11 +298,6 @@ func (in *EnvironmentSpec) DeepCopyInto(out *EnvironmentSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Endpoint != nil {
-		in, out := &in.Endpoint, &out.Endpoint
-		*out = new(string)
-		**out = **in
-	}
 	if in.Lifecycle != nil {
 		in, out := &in.Lifecycle, &out.Lifecycle
 		*out = new(corev1.Lifecycle)

--- a/pkg/cmd/seactl/env/sync.go
+++ b/pkg/cmd/seactl/env/sync.go
@@ -89,7 +89,7 @@ func (s *Sync) RunE(cmd *cobra.Command, args []string) error { //nolint:funlen,g
 		console.Fatal("Unable to calculate the archive checksum: %s", err)
 	}
 
-	upload := v1beta1.NewClient(*env.Endpoint + "/upload")
+	upload := v1beta1.NewClient(env.Endpoint + "/upload")
 	resp, err := upload.Upload(ctx, archive, map[string]string{
 		"name":      manifest.Name,
 		"namespace": env.Namespace,


### PR DESCRIPTION
Set a default client endpoint to `http://localhost:8080`.

* [x] Move endpoint to `ManifestEnvironmentSpec`.  Endpoint used to be used for the storage endpoint which is now set in the `SeawayConfig`.  Since endpoint is only used by the client, it was moved out of the environment and into the manifest specific config.
* [x] Added Makefile target to install controller for local testing
