### PR TITLE
feat: enable helm deps

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #.idea/
 
 .creds
+
+# Helm chart registry
+charts/

--- a/example/k8s/base/database.yaml
+++ b/example/k8s/base/database.yaml
@@ -1,0 +1,35 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: example
+spec:
+  postgresVersion: 16
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  # backups:
+  #   pgbackrest:
+  #     repos:
+  #     - name: repo1
+  #       volume:
+  #         volumeClaimSpec:
+  #           accessModes:
+  #           - "ReadWriteOnce"
+  #           resources:
+  #             requests:
+  #               storage: 1Gi
+  #     - name: repo2
+  #       volume:
+  #         volumeClaimSpec:
+  #           accessModes:
+  #           - "ReadWriteOnce"
+  #           resources:
+  #             requests:
+  #               storage: 1Gi
+  # proxy:
+  #   pgBouncer: {}

--- a/example/k8s/base/kustomization.yaml
+++ b/example/k8s/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  ctx.sh/authors: "Seaway Authors"
+  ctx.sh/license: "Apache"
+  ctx.sh/support: "https://github.com/ctxswitch/seaway/issues"
+resources:
+  - github.com/CrunchyData/postgres-operator/config/crd
+  - database.yaml

--- a/example/k8s/overlays/local/kustomization.yaml
+++ b/example/k8s/overlays/local/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  ctx.sh/authors: "Seaway Authors"
+  ctx.sh/license: "Apache"
+  ctx.sh/support: "https://github.com/ctxswitch/seaway/issues"
+resources:
+  - ../../base

--- a/example/k8s/pgo/kustomization.yaml
+++ b/example/k8s/pgo/kustomization.yaml
@@ -1,0 +1,11 @@
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+- name: pgo
+  repo: oci://registry.developers.crunchydata.com/crunchydata
+  releaseName: pgo
+  namespace: database-system
+  version: 5.7.0
+  valuesFile: values.yaml

--- a/example/k8s/pgo/values.yaml
+++ b/example/k8s/pgo/values.yaml
@@ -1,0 +1,3 @@
+debug: false
+singleNamespace: false
+disable_check_for_upgrades: false

--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -36,7 +36,8 @@ environments:
     resources:
       memory: 2Gi
       cpu: 100m
-    # dependencies:
-    #   - name: all
-    #     type: kustomize
-    #     base: k8s/overlays/local
+    dependencies:
+      - name: pgo
+        path: k8s/pgo
+      - name: base
+        path: k8s/base

--- a/pkg/cmd/seactl/env/clean.go
+++ b/pkg/cmd/seactl/env/clean.go
@@ -65,7 +65,7 @@ func (c Clean) RunE(cmd *cobra.Command, args []string) error {
 
 	console.Info("Cleaning environment '%s'", env.Name)
 
-	client, err := kube.NewSeawayClient("", kubeContext)
+	client, err := kube.NewKubectlCmd("", kubeContext)
 	if err != nil {
 		console.Fatal(err.Error())
 	}

--- a/pkg/cmd/seactl/env/sync.go
+++ b/pkg/cmd/seactl/env/sync.go
@@ -110,7 +110,7 @@ func (s *Sync) RunE(cmd *cobra.Command, args []string) error { //nolint:funlen,g
 
 	console.Info("Deploying")
 
-	client, err := kube.NewSeawayClient("", kubeContext)
+	client, err := kube.NewKubectlCmd("", kubeContext)
 	if err != nil {
 		console.Fatal("error getting seaway client: %s", err.Error())
 	}

--- a/pkg/util/kustomize/kustomizer.go
+++ b/pkg/util/kustomize/kustomizer.go
@@ -54,7 +54,12 @@ func NewKustomizer(opts *KustomizerOptions) (*Kustomizer, error) {
 		Reorder:           "none",
 		AddManagedbyLabel: false,
 		LoadRestrictions:  types.LoadRestrictionsRootOnly,
-		PluginConfig:      &types.PluginConfig{},
+		PluginConfig: &types.PluginConfig{
+			HelmConfig: types.HelmConfig{
+				Enabled: true,
+				Command: "helm",
+			},
+		},
 	})
 
 	target := filesys.MakeFsOnDisk()


### PR DESCRIPTION
Enables helm dependencies for kustomize.  Some of the client was redone to support edge cases that came up.  Primarily supporting default namespaces (will be updated later to isolate to specific namespaces), and some renaming.  There's still an issue in the apply step that needs to be addressed as it appears that when crds are loaded the api resources are not reflecting (reloading) the additional crds.  It will fail the first time with a not found (referencing the kind) but then install if it is run again.