### PR TITLE
chore: clean up kube client

### DIFF
--- a/pkg/cmd/seactl/deps/apply.go
+++ b/pkg/cmd/seactl/deps/apply.go
@@ -60,7 +60,8 @@ func (a *Apply) RunE(cmd *cobra.Command, args []string) error {
 
 	// Load the manifest and grab the appropriate environment
 	var manifest v1beta1.Manifest
-	if err := manifest.Load("manifest.yaml"); err != nil {
+	err = manifest.Load("manifest.yaml")
+	if err != nil {
 		console.Fatal("Unable to load manifest")
 	}
 

--- a/pkg/cmd/seactl/deps/apply.go
+++ b/pkg/cmd/seactl/deps/apply.go
@@ -46,6 +46,10 @@ func NewApply() *Apply {
 // RunE generates and applies the dependencies for a development environment.
 func (a *Apply) RunE(cmd *cobra.Command, args []string) error {
 	kubeContext := cmd.Root().Flags().Lookup("context").Value.String()
+	client, err := kube.NewKubectlCmd("", kubeContext)
+	if err != nil {
+		console.Fatal(err.Error())
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -63,11 +67,6 @@ func (a *Apply) RunE(cmd *cobra.Command, args []string) error {
 	env, err := manifest.GetEnvironment(args[0])
 	if err != nil {
 		console.Fatal("Build environment '%s' not found in the manifest", args[0])
-	}
-
-	client, err := kube.NewKubectlCmd("", kubeContext)
-	if err != nil {
-		console.Fatal(err.Error())
 	}
 
 	console.Info("Applying dependencies for the '%s' environment", env.Name)

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -19,24 +19,17 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 
-	"ctx.sh/seaway/pkg/console"
-	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-// Client defines a new kubernetes client which impletments the RESTClientGetter interface
+// Client defines a new kubernetes client which implements the RESTClientGetter interface
 // Originally the controller-runtime clients were used but as kustomize was introduced, more
 // control was needed to handle the unstructured objects and interact with the API server.
 // To make things consistent, all of the seactl clients will utilize this client.
@@ -45,7 +38,7 @@ type Client struct {
 }
 
 // NewClient creates a new kubernetes client.  It takes a kubeconfig file and a kubeconfig
-// named context as arguments.  Both valudes can be empty strings in which case the os
+// named context as arguments.  Both values can be empty strings in which case the os
 // default paths will be checked for the kubeconfig file and the default context will be
 // used.
 func NewClient(kubeconfig string, context string) (*Client, error) {
@@ -80,6 +73,7 @@ func (c *Client) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return memory.NewMemCacheClient(dc), nil
 }
 
@@ -103,84 +97,6 @@ func (c *Client) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 // RESTClientGetter interface.
 func (c *Client) ToRESTConfig() (*rest.Config, error) {
 	return c.config.ClientConfig()
-}
-
-// ResourceInterfaceFor returns a new dynamic.ResourceInterface for the client.  It takes a
-// namespace (can be an empty string) and a runtime.Object as arguments.  The runtime.Object
-// is used to determine the group, version, and kind of the object which is then used to
-// configure the resource interface.  We use the mapping to determine the scope of the object
-// and if it is namespaced we create a namespaced resource interface.
-func (c *Client) ResourceInterfaceFor(obj Object, method string) (dynamic.ResourceInterface, error) {
-	gvk := obj.GetObjectKind().GroupVersionKind()
-
-	dc, err := c.ToDiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-
-	dyn, err := c.Factory().DynamicClient()
-	if err != nil {
-		console.Fatal(err.Error())
-	}
-
-	var dr dynamic.ResourceInterface
-
-	resource, err := ServerResourcesForGroupVersionKind(dc, gvk, method)
-	if err != nil {
-		return nil, err
-	}
-
-	gvr := gvk.GroupVersion().WithResource(resource.Name)
-	if resource.Namespaced {
-		if obj.GetNamespace() == "" {
-			obj.SetNamespace(corev1.NamespaceDefault)
-		}
-		dr = dyn.Resource(gvr).Namespace(obj.GetNamespace())
-	} else {
-		dr = dyn.Resource(gvr)
-	}
-
-	return dr, nil
-}
-
-// ServerResourcesForGroupVersionKind returns the APIResource for the provided GroupVersionKind.
-func ServerResourcesForGroupVersionKind(dc discovery.DiscoveryInterface, gvk schema.GroupVersionKind, verb string) (*metav1.APIResource, error) {
-	resources, err := dc.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, r := range resources.APIResources {
-		if r.Kind == gvk.Kind {
-			if supportedVerb(&r, verb) {
-				return &r, nil
-			}
-
-			return nil, apierr.NewMethodNotSupported(
-				schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind},
-				verb,
-			)
-		}
-	}
-
-	return nil, apierr.NewNotFound(
-		schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind},
-		"",
-	)
-}
-
-// supportedVerb returns true if the provided verb is supported by the APIResource.
-func supportedVerb(apiResource *metav1.APIResource, verb string) bool {
-	if verb == "" || verb == "*" {
-		return true
-	}
-
-	for _, v := range apiResource.Verbs {
-		if strings.EqualFold(v, verb) {
-			return true
-		}
-	}
-	return false
 }
 
 // loadConfig loads the kubernetes configuration from the provided kubeconfig file, Borrowed


### PR DESCRIPTION
Separated out some of the client functions that the restclientgetter interface don't need and push them into the kubectl command.