### PR TITLE
feat(deps): add conditional wait

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -39,5 +39,10 @@ environments:
     dependencies:
       - name: pgo
         path: k8s/pgo
+        wait:
+          - kind: Deployment
+            name: pgo
+            for: ready
+            timeout: 30s
       - name: base
         path: k8s/base

--- a/pkg/apis/seaway.ctx.sh/v1beta1/manifest_wait_condition.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/manifest_wait_condition.go
@@ -1,0 +1,31 @@
+package v1beta1
+
+import (
+	"fmt"
+	"time"
+)
+
+func (mw *ManifestWaitCondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type ManifestWaitConditionDefaulted ManifestWaitCondition
+	var defaults = ManifestWaitConditionDefaulted{
+		Timeout: 5 * time.Minute,
+		For:     "ready",
+	}
+
+	out := defaults
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+
+	if out.Kind == "" {
+		return fmt.Errorf("kind is required")
+	}
+
+	if out.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	tmpl := ManifestWaitCondition(out)
+	*mw = tmpl
+	return nil
+}

--- a/pkg/apis/seaway.ctx.sh/v1beta1/types.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/types.go
@@ -17,6 +17,8 @@ package v1beta1
 // +kubebuilder:docs-gen:collapse=Apache License
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -295,6 +297,30 @@ type ManifestDependency struct {
 	// Path is the path to the directory containing the manifests.
 	// +required
 	Path string `yaml:"path"`
+	// Wait is a wait condition that the controller will use to determine if the
+	// dependency has been successfully applied.
+	// +optional
+	// +nullable
+	Wait []ManifestWaitCondition `yaml:"wait"`
+}
+
+type ManifestWaitCondition struct {
+	// Kind is the kind of resource that the controller will use to match the resources
+	// to the wait condition.
+	// +required
+	Kind string `yaml:"kind"`
+	// Name is the name of the resource that the controller will use to match the resources
+	// to the wait condition.
+	// +required
+	Name string `yaml:"name"`
+	// For is the condition that the controller will wait for.  Default is `ready` which is an
+	// alias for `condition=ready` for Deployment like resources, and `readyReplicas=replicas` for
+	// StatefulSets.
+	// +optional
+	For string `yaml:"for"`
+	// Timeout is the timeout that the controller will wait for the condition.
+	// +optional
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 // ManifestEnvironmentSpec is a spec for an environment in the manifest and

--- a/pkg/console/output.go
+++ b/pkg/console/output.go
@@ -31,6 +31,7 @@ const (
 	ExBox      = "☒ "
 	EmptyBox   = "☐ "
 	CheckMark  = "✔ "
+	Ex         = "✘ "
 )
 
 //
@@ -59,7 +60,7 @@ func ListItem(format string, a ...any) {
 }
 
 func Fatal(format string, a ...any) {
-	format = chalk.Red.String() + format + "\n" + chalk.Reset.String()
+	format = chalk.Red.String() + Ex + format + "\n" + chalk.Reset.String()
 	fmt.Printf(format, a...)
 	os.Exit(1)
 }
@@ -110,5 +111,10 @@ func Updated(format string, a ...any) {
 
 func Unchanged(format string, a ...any) {
 	format = "  " + chalk.Blue.String() + CheckMark + chalk.Reset.String() + chalk.Inverse.String() + format + "\n" + chalk.Reset.String()
+	fmt.Printf(format, a...)
+}
+
+func Waiting(format string, a ...any) {
+	format = "  " + chalk.White.String() + CheckMark + chalk.Reset.String() + chalk.Inverse.String() + format + "\n" + chalk.Reset.String()
 	fmt.Printf(format, a...)
 }

--- a/pkg/kube/client/wait.go
+++ b/pkg/kube/client/wait.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/kubectl/pkg/util/interrupt"
+)
+
+// WaitOptions contains the options for used to wait on a condition.
+type WaitOptions struct {
+	timeout time.Duration
+	client  dynamic.ResourceInterface
+}
+
+// WaitCondition defines the conditions that needs to be satisfied.
+type WaitCondition struct {
+	// The name of the resource to wait for.  Used as the field selector for the list/watch.
+	name string
+	// The condition (or .status.type) to wait for.
+	condition string
+	// The kind of the object to wait for.
+	kind string
+}
+
+// NewWaitOptions creates a new WaitOptions with the provided options.
+func NewWaitCondition(name, kind, condition string) *WaitCondition {
+	return &WaitCondition{name: name, condition: condition, kind: kind}
+}
+
+// WaitForCondition creates a listwatch and blocks until the condition has
+// been met or a timeout occurs.
+func (w *WaitCondition) WaitForCondition(ctx context.Context, opts WaitOptions) error {
+	client := opts.client
+
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", w.name).String(),
+	}
+
+	lw := &cache.ListWatch{
+		ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
+			return client.List(ctx, options)
+		},
+		WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
+			return client.Watch(ctx, options)
+		},
+	}
+
+	preconditionFunc := func(store cache.Store) (bool, error) {
+		return false, nil
+	}
+
+	intrCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	intr := interrupt.New(nil, cancel)
+	err := intr.Run(func() error {
+		_, err := watchtools.UntilWithSync(intrCtx, lw, &unstructured.Unstructured{}, preconditionFunc, watchtools.ConditionFunc(w.isConditionMet))
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("timed out waiting for condition %s", w.condition)
+		}
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// isConditionMet checks a watch event and passes the object on to
+// the check function.
+func (w *WaitCondition) isConditionMet(event watch.Event) (bool, error) {
+	if event.Type == watch.Error {
+		err := apierr.FromObject(event.Object)
+		fmt.Fprintf(os.Stderr, "error: waiting for condition to be satisfied %v", err)
+		return false, nil
+	}
+	if event.Type == watch.Deleted {
+		return false, nil
+	}
+
+	obj, _ := event.Object.(*unstructured.Unstructured)
+	return w.checkCondition(obj)
+}
+
+// checkCondition parses the condition and routes it to the appropriate
+// check function to handle a specific type of check.
+func (w *WaitCondition) checkCondition(obj *unstructured.Unstructured) (bool, error) {
+	condition := strings.ToLower(w.condition)
+	switch {
+	case condition == "ready" && !strings.EqualFold(w.kind, "statefulset"):
+		return w.checkStatusCondition(obj, "available")
+	case condition == "ready" && strings.EqualFold(w.kind, "statefulset"):
+		return w.checkStatusReplicas(obj)
+	case strings.HasPrefix(condition, "condition="):
+		return w.checkStatusCondition(obj, strings.TrimPrefix(condition, "condition="))
+	}
+	return false, fmt.Errorf("unknown condition %s", condition)
+}
+
+// checkStatusCondition checks the condition list in the status block ensuring
+// that a condition type is equal to true.
+func (w *WaitCondition) checkStatusCondition(obj *unstructured.Unstructured, conditionString string) (bool, error) {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	for _, raw := range conditions {
+		condition, ok := raw.(map[string]interface{})
+		if !ok {
+			return false, nil
+		}
+
+		name, found, err := unstructured.NestedString(condition, "type")
+		if !found || err != nil || !strings.EqualFold(name, conditionString) {
+			continue
+		}
+
+		status, found, err := unstructured.NestedString(condition, "status")
+		if !found || err != nil {
+			continue
+		}
+
+		return strings.EqualFold(status, "true"), nil
+	}
+
+	return false, nil
+}
+
+// checkStatusReplicas is a status check for resources that do not have an
+// explicit condition that reports that the resource is ready.  It checks that
+// the number of updated and available replicas is equal to the number of
+// desired replicas.
+func (w *WaitCondition) checkStatusReplicas(obj *unstructured.Unstructured) (bool, error) {
+	replicas, found, err := unstructured.NestedFieldNoCopy(obj.Object, "status", "replicas")
+	if !found || err != nil {
+		return false, nil
+	}
+
+	availableReplicas, found, err := unstructured.NestedFieldNoCopy(obj.Object, "status", "availableReplicas")
+	if !found || err != nil {
+		return false, nil
+	}
+
+	updatedReplicas, found, err := unstructured.NestedFieldNoCopy(obj.Object, "status", "updatedReplicas")
+	if !found || err != nil {
+		return false, nil
+	}
+
+	isUpdated := updatedReplicas == replicas
+	isAvailable := availableReplicas == replicas
+
+	return isUpdated && isAvailable, nil
+}


### PR DESCRIPTION
Adds the ability to conditionally wait between dependency steps.  Currently the following are supported:

* `condition=<type>`
* `ready` which is an alias to `condition=Available`.  When `ready` is used with a resource that does not have a condition item of type `Available` (currently only statefulset is wired up) then updated and available replicas are compared with number of desired replicas.

A `jsonstring` condition is planned in the future which will allow custom checks.

Closes #61 