### PR TITLE
ctx/fix(tracker): client status not updated on controller reload

### DIFF
--- a/pkg/apis/seaway.ctx.sh/v1beta1/handlers/service/seaway/environment.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/handlers/service/seaway/environment.go
@@ -91,7 +91,11 @@ func (s *Service) send(
 
 	changed := track.HasChanged(namespace, name)
 	deployed := track.IsDeployed(namespace, name)
-	
+
+	// TODO: clean up the initializing logic here.  it's not very intuitive what
+	//   this is doing and why it is needed.  For reference there was a state at the
+	//   beginning of a deployment stream where we would duplicate sending a status
+	//   update when in initializing.
 	if (changed || deployed) && info.Status != "initializing" {
 		logger.V(6).Info("sending", "info", info)
 		err := stream.Send(&seawayv1beta1.EnvironmentResponse{

--- a/pkg/apis/seaway.ctx.sh/v1beta1/handlers/service/seaway/environment.go
+++ b/pkg/apis/seaway.ctx.sh/v1beta1/handlers/service/seaway/environment.go
@@ -89,7 +89,10 @@ func (s *Service) send(
 	}
 	logger.V(6).Info("info", "info", info)
 
-	if (track.HasChanged(namespace, name)) && info.Status != "initializing" {
+	changed := track.HasChanged(namespace, name)
+	deployed := track.IsDeployed(namespace, name)
+	
+	if (changed || deployed) && info.Status != "initializing" {
 		logger.V(6).Info("sending", "info", info)
 		err := stream.Send(&seawayv1beta1.EnvironmentResponse{
 			Stage:  info.Stage,

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -76,3 +76,15 @@ func (t *Tracker) HasChanged(namespace, name string) bool {
 
 	return info.Stage != info.LastStage
 }
+
+func (t *Tracker) IsDeployed(namespace, name string) bool {
+	t.Lock()
+	defer t.Unlock()
+
+	info, ok := t.envs[types.NamespacedName{Namespace: namespace, Name: name}]
+	if !ok {
+		return false
+	}
+
+	return info.Status == "deployed"
+}


### PR DESCRIPTION
* There was an issue where the environment stream handler was not sending the current state of a deployed environment after the controller was reloaded.  This was due to the tracker not recognizing that there was a change when it was reinitialized from the cached items (both last and current stage were the same).
* Adds a new `isDeployed` function and we now stream the environment information back to the client if it has been changed or it has been deployed.
* There's still the odd initialized condition for the stream response that I'd like to clean up and clarify that logic.