### PR TITLE
ctx/feat(sync): respect env namespaces

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -6,7 +6,7 @@ defaultEnvironment: local
 environments:
   - name: local
     replicas: 3
-    namespace: default
+    namespace: seaway-example
     vars:
       env:
         - name: ENV

--- a/pkg/cmd/seactl/logs/build.go
+++ b/pkg/cmd/seactl/logs/build.go
@@ -40,11 +40,6 @@ func (l *BuildLogs) RunE(cmd *cobra.Command, args []string) error {
 		console.Fatal("Unable to load manifest")
 	}
 
-	env, err := manifest.GetEnvironment(args[0])
-	if err != nil {
-		console.Fatal("Build environment '%s' not found in the manifest", args[0])
-	}
-
 	streamer, err := client.NewLogStreamer(kubeContext, corev1.PodLogOptions{
 		Follow:     l.follow,
 		TailLines:  &l.tail,
@@ -56,7 +51,7 @@ func (l *BuildLogs) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	labels := fmt.Sprintf("app=%s,group=build", manifest.Name)
-	err = streamer.PodLogs(ctx, env.Namespace, labels)
+	err = streamer.PodLogs(ctx, v1beta1.DefaultControllerNamespace, labels)
 	if err != nil && err != context.Canceled {
 		console.Fatal(err.Error())
 	}

--- a/pkg/cmd/seactl/sync/sync.go
+++ b/pkg/cmd/seactl/sync/sync.go
@@ -217,7 +217,7 @@ func doSync(ctx context.Context, client *kube.KubectlCmd, name string, env v1bet
 	op, err := client.CreateOrUpdate(ctx, ns, func() error {
 		// TODO: we can set some labels here later.
 		// TODO: figure out what we want to do to clean up.  This will need to
-		//   be seperate from the environment (maybe some sort of a gc process
+		//   be separate from the environment (maybe some sort of a gc process
 		//   in the controller).  Will need to figure out how to determine whether
 		//   or not we've created it so we don't remove namespaces that we don't
 		//   manage.
@@ -226,7 +226,7 @@ func doSync(ctx context.Context, client *kube.KubectlCmd, name string, env v1bet
 	if err != nil {
 		console.Fatal("Unable to create namespace: %s", err.Error())
 	}
-	switch op {
+	switch op { // nolint:gocritic
 	case kube.OperationResultCreated:
 		console.Info("Environment created")
 	}

--- a/pkg/cmd/util/utils.go
+++ b/pkg/cmd/util/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
 
@@ -146,4 +147,16 @@ func GetEnvironment(name, namespace string) *v1beta1.Environment {
 	env.SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("Environment"))
 
 	return env
+}
+
+// GetNamespace returns a new namespace object
+func GetNamespace(name string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	ns.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+
+	return ns
 }

--- a/pkg/cmd/util/utils.go
+++ b/pkg/cmd/util/utils.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"ctx.sh/seaway/pkg/apis/seaway.ctx.sh/v1beta1"
 	"ctx.sh/seaway/pkg/console"
@@ -149,7 +150,7 @@ func GetEnvironment(name, namespace string) *v1beta1.Environment {
 	return env
 }
 
-// GetNamespace returns a new namespace object
+// GetNamespace returns a new namespace object.
 func GetNamespace(name string) *corev1.Namespace {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
* [x] Create the namespace if it does not exist.
* [x] Quick one off fix from moving the jobs to the controller namespace.  This points the `logs.build` streamer to the controller namespace instead of the environment namespace.